### PR TITLE
remove unreachable code rule

### DIFF
--- a/test/scripts/no-unreachable/invalid.ts
+++ b/test/scripts/no-unreachable/invalid.ts
@@ -1,6 +1,0 @@
-function a() {
-  return 5;
-  return 6;
-}
-
-a();

--- a/test/scripts/no-unreachable/valid.ts
+++ b/test/scripts/no-unreachable/valid.ts
@@ -1,9 +1,0 @@
-function a(x) {
-  if (x) {
-    return 5;
-  } else {
-    return 6;
-  }
-}
-
-a(true);

--- a/tslint.json
+++ b/tslint.json
@@ -17,7 +17,6 @@
     "no-invalid-this": [true, "check-function-in-method"],
     "no-shadowed-variable": true,
     "no-switch-case-fall-through": true,
-    "no-unreachable": true,
     "no-unused-variable": [true, "react"],
     "no-var-keyword": true,
     "switch-default": true,


### PR DESCRIPTION
This rule is deprecated in `tslint@next`, the compiler emits corresponding errors in compile time: https://github.com/Microsoft/TypeScript/pull/4788.